### PR TITLE
Fix #1 - android compilation error for lambda by enforcing language 8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,6 +24,11 @@ apply plugin: "com.android.library"
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         minSdkVersion 19
     }


### PR DESCRIPTION
As code is utilising the lang 8 feature so enforcing the lang 8 feature for compilation.  

NOTE : in scenario of Multi-Module project, other package may run on lower language than 8